### PR TITLE
Add header for Azure blob uploads

### DIFF
--- a/examples/publish_course_manual/publish_manual.sh
+++ b/examples/publish_course_manual/publish_manual.sh
@@ -196,6 +196,7 @@ UploadAttachments () {
                        --header "Content-Length: $(wc -c "$file_path" | awk '{print $1}')" \
                        --header "Content-Type: $(file -b --mime-type "$file_path")" \
                        --header "Content-MD5: $(MD5inBase64 "$file_path")" \
+                       --header "x-ms-blob-type: BlockBlob" \
                        --header "Content-Disposition: inline; filename=\"$(basename "$file_path")\"; filename*=UTF-8''$(basename "$file_path")")
     fi
   done

--- a/examples/publish_course_manual_rb/publish_manual.rb
+++ b/examples/publish_course_manual_rb/publish_manual.rb
@@ -68,7 +68,8 @@ class ManualPublisher
           "Accept" => "application/json",
           "Content-Type" => file_info[:content_type],
           "Content-MD5" => file_info[:checksum],
-          "Content-Length" => file_info[:byte_size]  
+          "Content-Length" => file_info[:byte_size],
+          "x-ms-blob-type" => 'BlockBlob'
         }
       )
     end


### PR DESCRIPTION
- Add `x-ms-blob-type` header to direct upload requests in API manual publishing scripts
- Without this header, uploads to Azure blob storage will fail
- I tested the scripts against minio blob storage with this header to ensure backwards compatibility
- Azure blob storage API reference available here: https://learn.microsoft.com/en-us/rest/api/storageservices/put-blob