### PR TITLE
Handles no content more gracefully (2375) 

### DIFF
--- a/examples/course_manual_publisher/lib/course_manual_publisher.rb
+++ b/examples/course_manual_publisher/lib/course_manual_publisher.rb
@@ -26,6 +26,7 @@ require "nokogiri"
 require "rest-client"
 
 class CourseManualPublisher
+  class NoContentError < StandardError; end
   class UnexpectedStateError < StandardError; end
 
   POLL_SLEEP_SECS = 5
@@ -83,6 +84,8 @@ class CourseManualPublisher
     puts "Done."
   rescue UnexpectedStateError => e
     die e.message
+  rescue NoContentError
+    puts "There are no changes to publish."
   rescue RestClient::NotFound
     die "Course ID not valid"
   rescue RestClient::Unauthorized
@@ -212,6 +215,7 @@ class CourseManualPublisher
         "Authorization" => authorization
       }
     )
+    raise NoContentError if r.code == 204
 
     JSON.parse(r.body) if r.body.present?
   end


### PR DESCRIPTION
https://jira.corp.skytap.com/browse/CMGR-2375

- Outputs "There are no changes to publish." and exits if there is no draft at any point in the script if we are checking for the draft's state.